### PR TITLE
Path fix for generated ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Protocol Buffer Definitions for Rainblock",
-  "main": "generated/index.js",
-  "types": "generated/index.d.ts",
+  "main": "generated/ts/index.js",
+  "types": "generated/ts/index.d.ts",
   "scripts": {
     "preinstall": "mkdir -p prototool;curl -sSL https://github.com/uber/prototool/releases/download/v1.3.0/prototool-$(uname -s)-$(uname -m).tar.gz | tar -C prototool --strip-components 1 -xz",
     "format": "prototool/bin/prototool all src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "./node_modules/gts/tsconfig-google.json",
     "compilerOptions": {
       "rootDir": "ts",
-      "outDir": "generated"
+      "outDir": "generated/ts"
     },
     "include": [
       "ts/*.ts"


### PR DESCRIPTION
# Description

This PR fixes an issue where the generated typescript used the wrong relative path for including the generated protobuf files, causing include errors.

