### PR TITLE
fix travis build: use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '11'
+dist: xenial
 sudo: false
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated/ts/index.js",
   "types": "generated/ts/index.d.ts",


### PR DESCRIPTION
# Description

This PR changes the Travis-CI build to use xenial, which should fix protoc errors due to outdated libraries:

```
/home/travis/build/RainBlock/rainblock-protocol/node_modules/grpc-tools/bin/protoc: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.8' not found (required by /home/travis/build/RainBlock/rainblock-protocol/node_modules/grpc-tools/bin/protoc)
/home/travis/build/RainBlock/rainblock-protocol/node_modules/grpc-tools/bin/protoc: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /home/travis/build/RainBlock/rainblock-protocol/node_modules/grpc-tools/bin/protoc
```