### PR TITLE
Fix include/generation paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@rainblock/protocol",
   "version": "1.0.3",
   "description": "Protocol Buffer Definitions for Rainblock",
-  "main": "generated/ts/index.js",
-  "types": "generated/ts/index.d.ts",
+  "main": "generated_ts/index.js",
+  "types": "generated_ts/index.d.ts",
   "scripts": {
     "preinstall": "mkdir -p prototool;curl -sSL https://github.com/uber/prototool/releases/download/v1.3.0/prototool-$(uname -s)-$(uname -m).tar.gz | tar -C prototool --strip-components 1 -xz",
     "format": "prototool/bin/prototool all src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "./node_modules/gts/tsconfig-google.json",
     "compilerOptions": {
       "rootDir": "ts",
-      "outDir": "generated/ts"
+      "outDir": "generated_ts"
     },
     "include": [
       "ts/*.ts"


### PR DESCRIPTION
# Description

This PR fixes an issue with the generated typescript where the wrong include path was being used, leading to path errors when the library was included.

