### PR TITLE
Refactor to remove per account data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated_ts/index.js",
   "types": "generated_ts/index.d.ts",

--- a/src/clientVerifier.proto
+++ b/src/clientVerifier.proto
@@ -20,10 +20,10 @@ message TransactionRequest {
   bytes transaction = 1;
   // The serialized account witnesses, with format described above
   repeated bytes account_witnesses = 2;
-  // Code which was accessed during the account execution, as raw bytes
+  // Any code accessed during the account execution, as raw bytes
   // Ordering is not required because the code will be hashed by the client
   // and the hash will be used as the key.
-  repeated bytes account_code = 3;
+  repeated bytes code_list = 3;
   // A "bag" of all storage witnesses accessed during the message call/transaction,
   // with the same format as the account witnesses described above.
   repeated bytes storage_witnesses = 4;

--- a/src/clientVerifier.proto
+++ b/src/clientVerifier.proto
@@ -20,18 +20,13 @@ message TransactionRequest {
   bytes transaction = 1;
   // The serialized account witnesses, with format described above
   repeated bytes account_witnesses = 2;
-  // Code and storage data for accounts which were accesssed.
-  repeated AccountData account_data = 3;
-}
-
-// Data for an account which may include storage witnesses and code.
-message AccountData {
-  // The 20-byte address this witness is for. Should be a big endian integer.
-  bytes address = 1;
-  // The serialized storage witness, with format described above
-  repeated bytes storage_witnesses = 2;
-  // The code which corresponds to the account, if present.
-  bytes code = 3;
+  // Code which was accessed during the account execution, as raw bytes
+  // Ordering is not required because the code will be hashed by the client
+  // and the hash will be used as the key.
+  repeated bytes account_code = 3;
+  // A "bag" of all storage witnesses accessed during the message call/transaction,
+  // with the same format as the account witnesses described above.
+  repeated bytes storage_witnesses = 4;
 }
 
 // The error code, indicating whether the transaction was successfully submitted (but not necessarily accepted) by


### PR DESCRIPTION
# Description

This PR removes per account data as it is not needed anymore and adds unnecessary overhead to the protobuf.

Since the verifier needs to hash the code it receives (it cannot trust the client to provide correct code), 
it will generate a map from codeHash -> code which it can efficiently lookup using the codeHash in the  RLP-encoded account.

Similarly, for the storage witnesses, using the storageRoot as the "starting" pointer for the storage removes the need to have per-account storage, as the verifier will hash all received nodes anyway.