### PR TITLE
Add stale addresses to verifier response to client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated_ts/index.js",
   "types": "generated_ts/index.d.ts",

--- a/src/clientVerifier.proto
+++ b/src/clientVerifier.proto
@@ -44,4 +44,6 @@ enum ErrorCode {
 message TransactionReply {
   // The return response code.
   ErrorCode code = 1;
+  // The addresses of any accounts that the verifier has discovered have stale witnesses
+  repeated bytes stale_addresses = 2;
 }


### PR DESCRIPTION
# Description

The client needs some feedback on when to throw away cached witnesses and fetch fresh ones from the storage layer. The verifier, when verifying transactions, should encounter accounts with stale witnesses. This change enables the verifier to report the addresses of such accounts to the client.
