### PR TITLE
Minimize verifier-storage overhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated_ts/index.js",
   "types": "generated_ts/index.d.ts",

--- a/src/verifierStorage.proto
+++ b/src/verifierStorage.proto
@@ -20,82 +20,23 @@ message UpdateMsg {
   bytes merkle_tree_nodes = 1;
   // RLP serialization of the new block
   bytes rlp_block = 2;
-  // A list of state update operations for the new block
+  // A list of state update operations for the new block.
   repeated UpdateOp operations = 3;
 }
 
-// UpdateOp to update the state in the storage nodes
+// Used for each update to the node's merkle tree.
 message UpdateOp {
-  // A state update operation can be either an ValueChangeOp,
-  // DeletionOp, CreationOP or an ExecutionOp
-  oneof updates {
-    ValueChangeOp value = 1;
-    DeletionOp delete = 2;
-    CreationOp create = 3;
-    ExecutionOp execute = 4;
-  }
-}
-
-// ValueChangeOp to modify the balance and nonce of an account in global state
-message ValueChangeOp {
-  // Address of the account to be modified
-  bytes account = 1; // 20 byte big endian account number
-  // Modified account balance
-  bytes value = 2; // 32 byte big endian unsigned integer
-  // Number of times an account is modified;
-  // required to update the account nonce
-  uint32 changes = 3;
-}
-
-// DeletionOp to delete an existing account in the global state
-message DeletionOp {
-  // Address of the account to be deleted
-  bytes account = 1; // 20 byte big endian account number
-}
-
-// CreationOp to create a new account in the global state
-message CreationOp {
-  // Address of the an account to be created
-  bytes account = 1; // 20 byte big endian account number
-  // Balance of the new account
-  bytes value = 2; // 32 byte big endian unsigned integer
-  // Code to initialize the account with
-  bytes code = 3;
-  // A list of key, value pairs corresponding to the account storage
-  repeated StorageInsertion storage = 4;
-}
-
-// ExecutionOp to modify an accounts balance and storage in the global state 
-// resulting from a contract execution
-message ExecutionOp {
-  // Address of the account
-  bytes account = 1; // 20 byte big endian account number
-  // Account's updated balance
-  bytes value = 2; // 32 byte big endian unsigned integer
-  // Account's updated storage entries
-  repeated StorageUpdate storage = 3;
+  bytes account = 1; // 20 bytes, BE account number
+  bytes balance = 2; //  32 bytes, BE new balance. May not be present if the balance is unchanged.
+  uint32 updates = 3; // Increment by one for each nonce update. May not be present if the nonce is unchanged.
+  repeated StorageUpdate storage_update = 4; // Storage updates, if any.
+  bytes code = 5; // Code bytes, only applicable for creation of a contract account.
+  bool deleted = 6; // Set if the account was deleted. All other fields, if present, are ignored.
 }
 
 // StorageUpdate op to update a global state account's internal storgage
 message StorageUpdate {
-  // Storage entries (insert new/modified entries or
-  // delete existing entries)
-  oneof updates {
-    StorageInsertion inserts = 1;
-    StorageDeletion deletes = 2;
-  }
-}
-
-// StorageInsertion op to insert a new storgae entry into a global state account
-message StorageInsertion {
-  // Storage entry to be inserted or updated
   bytes key = 1; // 32 byte big endian unsigned integer
   // New or updated value of the storage entry
-  bytes value = 2; // 32 byte big endian unsigned integer
-}
-
-// StorageDeletion op to delete an account's internal storage entry
-message StorageDeletion {
-  // Storage entry to be deleted
-  bytes key = 1; // 32 byte big endian unsigned integer
+  bytes value = 2; // 32 byte big endian unsigned integer, or 0 if the key was deleted.
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,7 +1,7 @@
 import { VerifierService, VerifierClient, IVerifierServer, IVerifierClient } from '../generated/clientVerifier_grpc_pb'
 import { TransactionRequest, TransactionReply, ErrorCode } from '../generated/clientVerifier_pb';
 import { VerifierStorageService, VerifierStorageClient, IVerifierStorageClient, IVerifierStorageService, IVerifierStorageServer } from '../generated/verifierStorage_grpc_pb'
-import { UpdateMsg, UpdateOp, ValueChangeOp, DeletionOp, CreationOp, ExecutionOp, StorageDeletion, StorageInsertion, StorageUpdate } from '../generated/verifierStorage_pb';
+import { UpdateMsg, UpdateOp, StorageUpdate } from '../generated/verifierStorage_pb';
 import { StorageNodeClient, StorageNodeService, IStorageNodeClient, IStorageNodeServer } from '../generated/clientStorage_grpc_pb';
 import { MerklePatriciaTreeNode, RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, StorageRequest, StorageReply, BlockHashReply, BlockHashRequest } from '../generated/clientStorage_pb';
 
@@ -11,8 +11,7 @@ import * as grpc from 'grpc';
 
 export { VerifierService, VerifierClient, TransactionRequest, TransactionReply, IVerifierClient, 
     IVerifierServer, ErrorCode, VerifierStorageService, VerifierStorageClient, IVerifierStorageClient, 
-    IVerifierStorageServer, UpdateMsg, UpdateOp, ValueChangeOp, DeletionOp, CreationOp, ExecutionOp, 
-    StorageDeletion, StorageInsertion, StorageUpdate,
+    IVerifierStorageServer, UpdateMsg, UpdateOp, StorageUpdate,
     StorageNodeClient, StorageNodeService, IStorageNodeClient, IStorageNodeServer,
     MerklePatriciaTreeNode, RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, 
     StorageRequest, StorageReply, BlockHashReply, BlockHashRequest,


### PR DESCRIPTION
# Description

This PR reduces the complexity of the verifier-storage protocol by eliminating the use of `oneof` and unifying all updates to a single message type. This reduces the storage overhead of some messages, see #16 for a discussion.

It is a breaking API change, however, so the major version has been incremented to 2.0.0.

Fixes #16
