### PR TITLE
Remove extra abstraction in RPCWitness class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "1.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated_ts/index.js",
   "types": "generated_ts/index.d.ts",

--- a/src/clientStorage.proto
+++ b/src/clientStorage.proto
@@ -13,15 +13,11 @@ service StorageNode {
   rpc GetBlockHash(BlockHashRequest) returns (BlockHashReply);
 }
 
-// Serialization of a MPTN, needed to define a proper RPCWitness 
-message MerklePatriciaTreeNode {
-  bytes encoding = 1; // The RLP encoding of the entire node
-}
-
 // Serialization of the result of a get() on the MPT 
 message RPCWitness {
   bytes value = 1; // This is an RLP encoding of the account
-  repeated MerklePatriciaTreeNode proof = 2;
+  // Each proof is an RLP encoding of a MerklePatriciaTreeNode
+  repeated bytes proof_list = 2;
 }
 
 // Get the code whose corresponding account is at the provided address.

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -3,7 +3,7 @@ import { TransactionRequest, TransactionReply, ErrorCode } from '../generated/cl
 import { VerifierStorageService, VerifierStorageClient, IVerifierStorageClient, IVerifierStorageService, IVerifierStorageServer } from '../generated/verifierStorage_grpc_pb'
 import { UpdateMsg, UpdateOp, StorageUpdate } from '../generated/verifierStorage_pb';
 import { StorageNodeClient, StorageNodeService, IStorageNodeClient, IStorageNodeServer } from '../generated/clientStorage_grpc_pb';
-import { MerklePatriciaTreeNode, RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, StorageRequest, StorageReply, BlockHashReply, BlockHashRequest } from '../generated/clientStorage_pb';
+import { RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, StorageRequest, StorageReply, BlockHashReply, BlockHashRequest } from '../generated/clientStorage_pb';
 
 import * as google_protobuf_empty_pb from "google-protobuf/google/protobuf/empty_pb";
 import * as grpc from 'grpc';
@@ -13,6 +13,6 @@ export { VerifierService, VerifierClient, TransactionRequest, TransactionReply, 
     IVerifierServer, ErrorCode, VerifierStorageService, VerifierStorageClient, IVerifierStorageClient, 
     IVerifierStorageServer, UpdateMsg, UpdateOp, StorageUpdate,
     StorageNodeClient, StorageNodeService, IStorageNodeClient, IStorageNodeServer,
-    MerklePatriciaTreeNode, RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, 
+    RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, 
     StorageRequest, StorageReply, BlockHashReply, BlockHashRequest,
     IVerifierStorageService, google_protobuf_empty_pb, grpc };


### PR DESCRIPTION
# Description

For both ease of programming and less complex serialization, remove the `MerklePatriciaTreeNode` message, which was just a thin wrapper around a `bytes` message.