### PR TITLE
Have verifier send nonce instead of just the updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ prototool
 node_modules
 .github
 generated
+generated_ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated_ts/index.js",
   "types": "generated_ts/index.d.ts",

--- a/src/verifierStorage.proto
+++ b/src/verifierStorage.proto
@@ -28,7 +28,7 @@ message UpdateMsg {
 message UpdateOp {
   bytes account = 1; // 20 bytes, BE account number
   bytes balance = 2; //  32 bytes, BE new balance. May not be present if the balance is unchanged.
-  uint32 updates = 3; // Increment by one for each nonce update. May not be present if the nonce is unchanged.
+  uint64 nonce = 3; // 8 bytes, new nonce. May not be present if the nonce is unchanged.
   repeated StorageUpdate storage_update = 4; // Storage updates, if any.
   bytes code = 5; // Code bytes, only applicable for creation of a contract account.
   bool deleted = 6; // Set if the account was deleted. All other fields, if present, are ignored.

--- a/src/verifierStorage.proto
+++ b/src/verifierStorage.proto
@@ -28,7 +28,7 @@ message UpdateMsg {
 message UpdateOp {
   bytes account = 1; // 20 bytes, BE account number
   bytes balance = 2; //  32 bytes, BE new balance. May not be present if the balance is unchanged.
-  uint64 nonce = 3; // 8 bytes, new nonce. May not be present if the nonce is unchanged.
+  uint64 nonce = 3; //  New nonce. May not be present if the nonce is unchanged.
   repeated StorageUpdate storage_update = 4; // Storage updates, if any.
   bytes code = 5; // Code bytes, only applicable for creation of a contract account.
   bool deleted = 6; // Set if the account was deleted. All other fields, if present, are ignored.


### PR DESCRIPTION
# verifierStorage: Have verifier send the updated nonce instead of the number of updates

This PR updates the `verifierStorage.proto`, to have the updated nonce instead of the number of updates in the per account `updateOp`.  Check out #20  for the discussion related to this change.
Also, adds generated_ts in .gitignore

Technically, it is API breaking so changes the major version.

Fixes #20
