### PR TITLE
Enable getAccounts to request for multiple addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainblock/protocol",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Protocol Buffer Definitions for Rainblock",
   "main": "generated_ts/index.js",
   "types": "generated_ts/index.d.ts",

--- a/src/clientStorage.proto
+++ b/src/clientStorage.proto
@@ -7,7 +7,7 @@ service StorageNode {
   // Handles get_code_size and copy_code 
   rpc GetCodeInfo(CodeRequest) returns (CodeReply);
   // Handles get_code_hash and get_balance 
-  rpc GetAccount(AccountRequest) returns (AccountReply);
+  rpc GetAccounts(AccountsRequest) returns (AccountsReply);
   // Handles get_storage 
   rpc GetStorage(StorageRequest) returns (StorageReply);
   rpc GetBlockHash(BlockHashRequest) returns (BlockHashReply);
@@ -44,14 +44,21 @@ message CodeReply {
 // account existence queries will also pull in the account value, if it exists.
 // This is an optimzation because we are assuming the EVM will soon access an account
 // that it has recently queried for existence.
-message AccountRequest {
-  bytes address = 1;
+message AccountsRequest {
+  repeated bytes addresses = 1;
 }
 
 message AccountReply {
   bool exists = 1;
   // witness is serialization of the account RLP value and its corresponding proof 
   RPCWitness witness = 2;
+}
+
+// The order of these accounts should be the EXACT SAME order as the addresses
+// in the corresponding AccountsRequest message. This prevents us from having to
+// create some map from address to AccountReply.
+message AccountsReply {
+  repeated AccountReply accounts = 1;
 }
 
 // Requests the value at the key in the storage trie of the given account 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -3,7 +3,7 @@ import { MerkleNodeAdvertisement, BlockAdvertisement, NeighborAdvertisement, Ver
 import { VerifierStorageService, VerifierStorageClient, IVerifierStorageClient, IVerifierStorageService, IVerifierStorageServer } from '../generated/verifierStorage_grpc_pb'
 import { UpdateMsg, UpdateOp, StorageUpdate } from '../generated/verifierStorage_pb';
 import { StorageNodeClient, StorageNodeService, IStorageNodeClient, IStorageNodeServer } from '../generated/clientStorage_grpc_pb';
-import { RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, StorageRequest, StorageReply, BlockHashReply, BlockHashRequest } from '../generated/clientStorage_pb';
+import { RPCWitness, CodeRequest, CodeReply, AccountsRequest, AccountReply, AccountsReply, StorageRequest, StorageReply, BlockHashReply, BlockHashRequest } from '../generated/clientStorage_pb';
 
 import * as google_protobuf_empty_pb from "google-protobuf/google/protobuf/empty_pb";
 import * as grpc from 'grpc';
@@ -13,7 +13,7 @@ export { VerifierService, VerifierClient, TransactionRequest, TransactionReply, 
     IVerifierServer, ErrorCode, VerifierStorageService, VerifierStorageClient, IVerifierStorageClient, 
     IVerifierStorageServer, UpdateMsg, UpdateOp, StorageUpdate,
     StorageNodeClient, StorageNodeService, IStorageNodeClient, IStorageNodeServer,
-    RPCWitness, CodeRequest, CodeReply, AccountRequest, AccountReply, 
+    RPCWitness, CodeRequest, CodeReply, AccountsRequest, AccountReply, AccountsReply,
     MerkleNodeAdvertisement, BlockAdvertisement, NeighborAdvertisement, VerifierVerifierHandshakeMessage,
     StorageRequest, StorageReply, BlockHashReply, BlockHashRequest,
     IVerifierStorageService, google_protobuf_empty_pb, grpc };


### PR DESCRIPTION
# Description

Previously, the `getAccount` request could only request an Account + Witness for a single address. This change allows the client to request witness paths for multiple addresses in a single `getAccounts` RPC call. This will reduce the number of round-trips from the client to the storage layer.
